### PR TITLE
Add openGraph meta tags to post pages

### DIFF
--- a/partials/head.hbs
+++ b/partials/head.hbs
@@ -27,6 +27,11 @@
 {{#unless isLocalhost}}
     <meta http-equiv="Content-Security-Policy" content="default-src https: 'unsafe-inline'">
 {{/unless}}
+{{#each og}}
+    {{#if this.content}}
+        <meta property="{{this.property}}" content="{{this.content}}" />
+    {{/if}}
+{{/each}}
 
 <link rel="shortcut icon" href="/static/base/favicon/favicon.ico">
 <link rel="apple-touch-icon" sizes="180x180" href="/static/base/favicon/apple-touch-icon.png">


### PR DESCRIPTION
Adds og meta tags og:title, og:description, og:url, og:image (if any), og:type, article:author to post head.